### PR TITLE
Fix code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/formloginbrute.rb
+++ b/formloginbrute.rb
@@ -71,7 +71,7 @@ module LoginFormBruteForcer
           login_request.body.scan(/"#{username_field.name}"/i).empty? and
           login_request.body.scan(/"#{username_field.name}"/i).empty?)
         puts "[+] Yatta, found default login credentials for #{url} - #{username}:#{password}\n".green
-        $logfile.info("[+] Yatta, found default login credentials for #{url} - #{username} / #{password}")
+        $logfile.info("[+] Yatta, found default login credentials for #{url} - #{username} / [redacted]")
         return username, password
       end
     rescue Mechanize::ResponseCodeError => exception


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_7/security/code-scanning/4](https://github.com/Brook-5686/Ruby_7/security/code-scanning/4)

To fix the problem, we need to ensure that sensitive information such as passwords is not logged in clear text. Instead, we should redact or mask the sensitive information before logging it. This can be done by replacing the actual password with a placeholder text like "[redacted]".

The best way to fix this without changing existing functionality is to modify the log message on line 74 to redact the password. We will replace the password with "[redacted]" in the log message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
