### PR TITLE
Fix code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/yasuo.rb
+++ b/yasuo.rb
@@ -491,8 +491,8 @@ private
     sleep 0.5
 
     if response and (response.code == "200" or response.code == "301")
-      $logfile.info("[+] Yatta, found default login credentials for #{url401} - #{username}:#{password}\n")
-      puts ("[+] Yatta, found default login credentials for #{url401} - #{username}:#{password}\n").green
+      $logfile.info("[+] Yatta, found default login credentials for #{url401} - #{username}:[redacted]\n")
+      puts ("[+] Yatta, found default login credentials for #{url401} - #{username}:[redacted]\n").green
       return username, password
     end
     #Smart brute-foce ends here    
@@ -505,8 +505,8 @@ private
       sleep 0.5
 
       if response and (response.code == "200" or response.code == "301")
-        $logfile.info("[+] Yatta, found default login credentials for #{url401} - #{username}:#{password}\n")
-        puts ("[+] Yatta, found default login credentials for #{url401} - #{username}:#{password}\n").green
+        $logfile.info("[+] Yatta, found default login credentials for #{url401} - #{username}:[redacted]\n")
+        puts ("[+] Yatta, found default login credentials for #{url401} - #{username}:[redacted]\n").green
         return username, password
       end
     end


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_7/security/code-scanning/3](https://github.com/Brook-5686/Ruby_7/security/code-scanning/3)

To fix the problem, we need to ensure that sensitive information such as passwords is not logged in clear text. Instead, we should mask or redact the password before logging it. This can be done by replacing the actual password with a placeholder text like "[redacted]".

The best way to fix the problem without changing existing functionality is to modify the lines where the password is logged. Specifically, we need to change the lines that log the credentials to replace the password with "[redacted]".

We will make changes to the file `yasuo.rb` at lines 494, 495, 508, and 509 to redact the password before logging.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
