### PR TITLE
Fix code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/formloginbrute.rb
+++ b/formloginbrute.rb
@@ -95,7 +95,7 @@ module LoginFormBruteForcer
       password_field.value = password
 
       begin
-        $logfile.info("Trying combination --> #{username}/#{password}")
+        $logfile.info("Trying combination --> #{username}/[redacted]")
 
         login_request = login_form.submit
 
@@ -107,7 +107,7 @@ module LoginFormBruteForcer
             login_request.body.scan(/"#{username_field.name}"/i).empty? and
             login_request.body.scan(/"#{username_field.name}"/i).empty?)
           puts "[+] Yatta, found default login credentials for #{url} - #{username} / #{password}\n".green
-          $logfile.info("[+] Yatta, found default login credentials for #{url} - #{username} / #{password}")
+          $logfile.info("[+] Yatta, found default login credentials for #{url} - #{username} / [redacted]")
           return username, password
         end
       rescue Mechanize::ResponseCodeError => exception


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_7/security/code-scanning/2](https://github.com/Brook-5686/Ruby_7/security/code-scanning/2)

To fix the problem, we need to ensure that sensitive information such as passwords is not logged in clear text. Instead, we should mask or redact the sensitive information before logging it. This can be done by replacing the actual password with a placeholder text like "[redacted]".

The best way to fix the problem without changing existing functionality is to modify the log messages to redact the password. Specifically, we need to update the log messages on lines 98 and 110 to replace the password with "[redacted]".


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
