### PR TITLE
Fix code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/formloginbrute.rb
+++ b/formloginbrute.rb
@@ -57,7 +57,8 @@ module LoginFormBruteForcer
     password_field.value = password
 
     begin
-      $logfile.info("Trying app-specific default creds first -> #{dcreds}")
+      redacted_dcreds = dcreds.gsub(/:.*$/, ":[redacted]")
+      $logfile.info("Trying app-specific default creds first -> #{redacted_dcreds}")
       puts ("[+] Trying app-specific default creds first -> #{dcreds}\n").green
 
       login_request = login_form.submit
@@ -71,7 +72,7 @@ module LoginFormBruteForcer
           login_request.body.scan(/"#{username_field.name}"/i).empty? and
           login_request.body.scan(/"#{username_field.name}"/i).empty?)
         puts "[+] Yatta, found default login credentials for #{url} - #{username}:#{password}\n".green
-        $logfile.info("[+] Yatta, found default login credentials for #{url} - #{username} / #{password}")
+        $logfile.info("[+] Yatta, found default login credentials for #{url} - #{username} / [redacted]")
         return username, password
       end
     rescue Mechanize::ResponseCodeError => exception
@@ -95,7 +96,7 @@ module LoginFormBruteForcer
       password_field.value = password
 
       begin
-        $logfile.info("Trying combination --> #{username}/#{password}")
+        $logfile.info("Trying combination --> #{username}/[redacted]")
 
         login_request = login_form.submit
 
@@ -107,7 +108,7 @@ module LoginFormBruteForcer
             login_request.body.scan(/"#{username_field.name}"/i).empty? and
             login_request.body.scan(/"#{username_field.name}"/i).empty?)
           puts "[+] Yatta, found default login credentials for #{url} - #{username} / #{password}\n".green
-          $logfile.info("[+] Yatta, found default login credentials for #{url} - #{username} / #{password}")
+          $logfile.info("[+] Yatta, found default login credentials for #{url} - #{username} / [redacted]")
           return username, password
         end
       rescue Mechanize::ResponseCodeError => exception


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_7/security/code-scanning/1](https://github.com/Brook-5686/Ruby_7/security/code-scanning/1)

To fix the problem, we need to ensure that sensitive information such as passwords is not logged in clear text. Instead, we can mask or redact the sensitive information before logging it. This can be achieved by replacing the actual password with a placeholder text like "[redacted]". This way, the logs will not contain any sensitive information, reducing the risk of exposure.

We will modify the lines where sensitive information is logged to replace the actual password with "[redacted]". Specifically, we will update lines 60, 74, 98, and 110 to redact the password before logging.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
