### PR TITLE
Fix code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/yasuo.rb
+++ b/yasuo.rb
@@ -491,8 +491,8 @@ private
     sleep 0.5
 
     if response and (response.code == "200" or response.code == "301")
-      $logfile.info("[+] Yatta, found default login credentials for #{url401} - #{username}:#{password}\n")
-      puts ("[+] Yatta, found default login credentials for #{url401} - #{username}:#{password}\n").green
+      $logfile.info("[+] Yatta, found default login credentials for #{url401} - #{username}:[redacted]\n")
+      puts ("[+] Yatta, found default login credentials for #{url401} - #{username}:[redacted]\n").green
       return username, password
     end
     #Smart brute-foce ends here    
@@ -505,8 +505,8 @@ private
       sleep 0.5
 
       if response and (response.code == "200" or response.code == "301")
-        $logfile.info("[+] Yatta, found default login credentials for #{url401} - #{username}:#{password}\n")
-        puts ("[+] Yatta, found default login credentials for #{url401} - #{username}:#{password}\n").green
+        $logfile.info("[+] Yatta, found default login credentials for #{url401} - #{username}:[redacted]\n")
+        puts ("[+] Yatta, found default login credentials for #{url401} - #{username}:[redacted]\n").green
         return username, password
       end
     end


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_7/security/code-scanning/5](https://github.com/Brook-5686/Ruby_7/security/code-scanning/5)

To fix the problem, we need to ensure that sensitive information such as passwords is not logged in clear text. Instead, we should mask or redact the sensitive parts of the information before logging. This can be done by replacing the actual password with a placeholder like "[redacted]".

The best way to fix this without changing existing functionality is to modify the logging statements to redact the password. Specifically, we need to change lines 494 and 508 to replace the password with "[redacted]".


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
